### PR TITLE
fix: add margin in main section of pdf showcase

### DIFF
--- a/packages/showcases/src/pages/NoSSR/pdf.tsx
+++ b/packages/showcases/src/pages/NoSSR/pdf.tsx
@@ -271,7 +271,7 @@ export default function PDF() {
     }
 
     return (
-        <div className="">
+        <div className="mb-16">
             <h1 className="font-bold text-2xl md:text-5xl mb-3">
                 Ask a paper anything!
             </h1>


### PR DESCRIPTION
Worked on Issue/Bug: [#75]

Added margin in the bottom of main section of pdf showcase to allow user to scroll.   